### PR TITLE
Do not install libraries that have been turned off for deal.II

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -419,6 +419,7 @@ default INSTALL_PATH=${HOME}/apps/candi/${PROJECT}
 default PROCS=1
 default STABLE_BUILD=true
 default USE_SNAPSHOTS=false
+default PACKAGES_OFF=""
 
 # Check if project was specified correctly
 if [ -d ${PROJECT} ]; then
@@ -658,7 +659,15 @@ for PACKAGE in ${PACKAGES[@]}; do
     SKIP=false
     case ${PACKAGE} in
         skip:*) SKIP=true;  PACKAGE=${PACKAGE#*:};;
-        once:*) SKIP=maybe; PACKAGE=${PACKAGE#*:};;
+        once:*) 
+          # If the package is turned off in the deal.II configuration, do not
+          # install it.
+          PACKAGE=${PACKAGE#*:};
+          if [[ ${PACKAGES_OFF} =~ ${PACKAGE} ]]; then
+            SKIP=true; 
+          else
+            SKIP=maybe;
+          fi;;
     esac
     
     # Check if the package exists

--- a/deal.II/platforms/supported/ubuntu15.platform
+++ b/deal.II/platforms/supported/ubuntu15.platform
@@ -15,7 +15,6 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-#once:boost
 once:parmetis
 once:superlu_dist
 once:hdf5

--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -90,3 +90,32 @@ INSTALL_PATH=${PREFIX_PATH}/${PROJECT}/${COMPILER}
 # installed.
 STABLE_BUILD=true
 #STABLE_BUILD=false
+
+
+####################################
+### DO NOT MODIFY THE CODE BELOW ###
+####################################
+
+# Loop over the options in DEAL_CONFOPTS and if the package is turned off, add
+# it to the PACKAGES_OFF list.
+for PACKAGE in ${DEAL_CONFOPTS[@]}; do
+  case ${PACKAGE} in
+      *DEAL_II_WITH*:BOOL=OFF)
+      PACKAGE_NAME=${PACKAGE##*WITH_};
+      PACKAGE_NAME=${PACKAGE_NAME%%:BOOL*};
+      PACKAGES_OFF=${PACKAGE_NAME}' '${PACKAGES_OFF};;
+  esac
+done
+
+# Turn off parmetis if metis is off.
+if [[ ${PACKAGES_OFF} =~ 'METIS' ]]; then
+  PACKAGES_OFF=${PACKAGES_OFF}' PARMETIS';
+fi
+
+# Turn off SuperLU_dist of Trilinos is off.
+if [[ ${PACKAGES_OFF} =~ 'TRILINOS' ]]; then
+  PACKAGES_OFF=${PACKAGES_OFF}' SUPERLU_DIST';
+fi
+
+# Transorm upper case to lower case.
+PACKAGES_OFF=${PACKAGES_OFF,,}


### PR DESCRIPTION
With this patch, if we turn off a package for deal.II this package is not installed. It's not the most elegant because I had to put some code in the configuration file but that significantly speeds up the compilation time.