### PR TITLE
Clear CMake cache before configuration.

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -286,6 +286,8 @@ package_build() {
             echo scons -j ${PROCS} ${SCONSOPTS} prefix=${INSTALL_PATH} $target >>candi_build
         done
     elif [ ${BUILDCHAIN} = "cmake" ]; then
+        rm -f ${BUILDDDIR}/CMakeCache.txt
+        rm -rf ${BUILDDIR}/CMakeFiles
         echo cmake ${CONFOPTS} -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} ${UNPACK_PATH}/${EXTRACTSTO} >>candi_configure
         for target in "${TARGETS[@]}"; do
             echo make ${MAKEOPTS} -j ${PROCS} $target >>candi_build


### PR DESCRIPTION
This is mainly for Trilinos. I messed up several times the path for BLAS and LAPACK and the only way to change the path was to delete the repository by hand. This fix this problem.