### PR TITLE
Update boost to boost-1.59

### DIFF
--- a/deal.II/packages/boost.package
+++ b/deal.II/packages/boost.package
@@ -1,7 +1,7 @@
-NAME=boost_1_58_0
+NAME=boost_1_59_0
 SOURCE=http://downloads.sourceforge.net/boost/
 PACKING=.tar.gz
-CHECKSUM=5a5d5614d9a07672e1ab2a250b5defc5
+CHECKSUM=51528a0e3b33d9e10aaa311d9eb451e3
 BUILDCHAIN=custom
 
 package_specific_build () {


### PR DESCRIPTION
There is a bug in boost-1.58 that prevents the use of serialization in deal.II https://github.com/dealii/dealii/issues/1591 This has been fixed in boost-1.59

@koecher there is a new version of superlu_dist but you have heavily patched the current one so I don't know how to proceed to update it.