### PR TITLE
Allow overwriting vars

### DIFF
--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -60,7 +60,7 @@ MKL=OFF
 
 #########################################################################
 # How many processes would you like to build using?
-PROCS=1
+PROCS=${PROCS:-1}
 
 #########################################################################
 # Prefix directory

--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -64,7 +64,7 @@ PROCS=${PROCS:-1}
 
 #########################################################################
 # Prefix directory
-PREFIX_PATH=~/apps/candi
+PREFIX_PATH=${PREFIX_PATH:-~/apps/candi}
 
 #########################################################################
 # Setup compiler name string


### PR DESCRIPTION
I would like to do something like
```
  PROCS=4 ./candi.sh
```
and this patch allows for it. Is that something you like @koecher ?