### PR TITLE
avoid forcing SuperLUDist/ParMETIS to on

### DIFF
--- a/deal.II/packages/dealii-prepare.package
+++ b/deal.II/packages/dealii-prepare.package
@@ -23,9 +23,6 @@ if [[ ${PACKAGES_OFF} =~ 'METIS' ]]; then
   PACKAGES_OFF=${PACKAGES_OFF}' SUPERLU_DIST';
   ParMetis=OFF
   SuperLUDist=OFF
-else
-  ParMETIS=ON
-  SuperLUDist=ON
 fi
 
 # Transform upper case to lower case.


### PR DESCRIPTION
If a platform defines SuperLUDist=OFF it will be forced to ON if we have
METIS, which then causes packages fail to build because they think
SuperLUDist is being installed. Fix this.