### PR TITLE
Allow overwriting vars

### DIFF
--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -60,7 +60,7 @@ MKL=OFF
 
 #########################################################################
 # How many processes would you like to build using?
-PROCS=1
+PROCS=${PROCS:-1}
 
 #########################################################################
 # Prefix directory

--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -64,7 +64,7 @@ PROCS=${PROCS:-1}
 
 #########################################################################
 # Prefix directory
-PREFIX_PATH=~/apps/candi
+PREFIX_PATH=${PREFIX_PATH:-~/apps/candi}
 
 #########################################################################
 # Setup compiler name string


### PR DESCRIPTION
A major new version for solving the problem.
    Warning: the usage interface is now:
    ./candi.sh
    ./candi.sh --prefix=<PREFIX_PATH> or -p=* | --PREFIX_PATH=*
    ./candi.sh --np=<PROCS> or -np=* | --procs=* | --PROCS=* | -j*
    ./candi.sh --platform=<PROJECT/platform/supported/myplatform>  or -pf=*
