### PR TITLE
Keyword load instead of skip

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -680,6 +680,7 @@ for PACKAGE in ${PACKAGES[@]}; do
     # Skip building this package if the user requests it
     SKIP=false
     case ${PACKAGE} in
+        load:*) SKIP=true; LOAD=true; PACKAGE=${PACKAGE#*:};;
         skip:*) SKIP=true;  PACKAGE=${PACKAGE#*:};;
         once:*) 
           # If the package is turned off in the deal.II configuration, do not
@@ -762,8 +763,13 @@ for PACKAGE in ${PACKAGES[@]}; do
         package_unpack
         package_build
     else
-        # Let the user know we're skipping the current package
-        cecho ${GOOD} "Skipping ${NAME}"
+        if [ ! -z "${LOAD}" ]; then
+            # Let the user know we're loading the current package
+            cecho ${GOOD} "Loading ${NAME}"
+        else
+            # Let the user know we're skipping the current package
+            cecho ${GOOD} "Skipping ${NAME}"
+        fi
     fi
     package_register
     package_conf

--- a/candi.sh
+++ b/candi.sh
@@ -766,6 +766,7 @@ for PACKAGE in ${PACKAGES[@]}; do
         if [ ! -z "${LOAD}" ]; then
             # Let the user know we're loading the current package
             cecho ${GOOD} "Loading ${NAME}"
+            unset LOAD
         else
             # Let the user know we're skipping the current package
             cecho ${GOOD} "Skipping ${NAME}"

--- a/deal.II/platforms/supported/centos7.platform
+++ b/deal.II/platforms/supported/centos7.platform
@@ -22,7 +22,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-skip:dealii-prepare
+load:dealii-prepare
 once:parmetis
 once:superlu_dist
 once:hdf5

--- a/deal.II/platforms/supported/fedora21.platform
+++ b/deal.II/platforms/supported/fedora21.platform
@@ -24,7 +24,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-skip:dealii-prepare
+load:dealii-prepare
 #once:boost
 once:parmetis
 once:superlu_dist

--- a/deal.II/platforms/supported/fedora22.platform
+++ b/deal.II/platforms/supported/fedora22.platform
@@ -24,7 +24,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-skip:dealii-prepare
+load:dealii-prepare
 once:parmetis
 once:superlu_dist
 once:hdf5

--- a/deal.II/platforms/supported/linux_cluster.platform
+++ b/deal.II/platforms/supported/linux_cluster.platform
@@ -17,7 +17,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-skip:dealii-prepare
+load:dealii-prepare
 once:zlib
 once:bzip2
 once:boost

--- a/deal.II/platforms/supported/opensuse12.platform
+++ b/deal.II/platforms/supported/opensuse12.platform
@@ -22,7 +22,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-skip:dealii-prepare
+load:dealii-prepare
 #once:boost
 once:parmetis
 once:superlu_dist

--- a/deal.II/platforms/supported/opensuse13.platform
+++ b/deal.II/platforms/supported/opensuse13.platform
@@ -17,7 +17,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-skip:dealii-prepare
+load:dealii-prepare
 #once:boost
 once:parmetis
 once:superlu_dist

--- a/deal.II/platforms/supported/rhel6.platform
+++ b/deal.II/platforms/supported/rhel6.platform
@@ -17,6 +17,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
+load:dealii-prepare
 once:parmetis
 once:superlu_dist
 once:hdf5

--- a/deal.II/platforms/supported/rhel7.platform
+++ b/deal.II/platforms/supported/rhel7.platform
@@ -19,6 +19,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
+load:dealii-prepare
 once:parmetis
 once:superlu_dist
 once:hdf5

--- a/deal.II/platforms/supported/ubuntu14.platform
+++ b/deal.II/platforms/supported/ubuntu14.platform
@@ -11,7 +11,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-skip:dealii-prepare
+load:dealii-prepare
 once:parmetis
 once:superlu_dist
 once:hdf5

--- a/deal.II/platforms/supported/ubuntu15.platform
+++ b/deal.II/platforms/supported/ubuntu15.platform
@@ -11,7 +11,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
-skip:dealii-prepare
+load:dealii-prepare
 once:parmetis
 once:superlu_dist
 once:hdf5


### PR DESCRIPTION
This patch introduces a new keyword "load" for the build option of packages in the specified platform file.
It is a little feature which enhances the readability of the platform files and the output of candi.sh.
Cf. also the discussion of #26