### PR TITLE
If MKL is ON, setting MKL_DIR is enough when using Trilinos.

### DIFF
--- a/deal.II/packages/trilinos.package
+++ b/deal.II/packages/trilinos.package
@@ -21,6 +21,13 @@ if [ ! -z "${LAPACK_DIR}" ]; then
 fi
 
 if [ ${MKL} = "ON" ]; then
+  if [ -z "${BLAS_DIR}" ] && [ -z "${LAPACK_DIR}" ]; then 
+    TRILINOS_CONFOPTS=" \
+    ${TRILINOS_CONFOPTS} \
+    -D BLAS_LIBRARY_DIRS:STRING=${MKL_DIR} \
+    -D LAPACK_LIBRARY_DIRS:STRING=${MKL_DIR} \
+    "
+  fi
   TRILINOS_CONFOPTS=" \
   ${TRILINOS_CONFOPTS} \
   -D BLAS_LIBRARY_NAMES:STRING='mkl_core;mkl_sequential' \


### PR DESCRIPTION
If ```BLAS_DIR``` and ```LAPACK_DIR``` are empty and ```MKL=ON``` use ```MKL_DIR```.

When you update SuperLU_dist, could you also check that it is picked up by Trilinos correctly. I get a warning about unused variable SuperLU_dist.