### PR TITLE
Trilinos multiversion

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -440,10 +440,6 @@ guess_architecture() {
 
 ###############################################################################
 # Start the build process
-
-# Set the default version of Trilinos to 12. This is overwritten for Ubuntu12
-TRILINOS_MAJOR_VERSION_AUTO=12
-
 export ORIG_DIR=`pwd`
 
 # Read configuration variables from candi.cfg
@@ -708,10 +704,6 @@ guess_architecture
 
 # Reset timings
 TIMINGS=""
-
-if [[ ${TRILINOS_MAJOR_VERSION} == "AUTO" ]]; then
-  TRILINOS_MAJOR_VERSION=${TRILINOS_MAJOR_VERSION_AUTO}
-fi
 
 # Fetch and build individual packages
 for PACKAGE in ${PACKAGES[@]}; do

--- a/deal.II/packages/cmake.package
+++ b/deal.II/packages/cmake.package
@@ -1,0 +1,15 @@
+VERSION=2.8.12.2
+NAME=cmake-${VERSION}
+SOURCE=http://www.cmake.org/files/v2.8/
+PACKING=.tar.gz
+BUILDCHAIN=cmake
+
+CHECKSUM=ignore
+if [ ${VERSION} = 2.8.12.2 ]; then
+    CHECKSUM=17c6513483d23590cbce6957ec6d1e66
+fi
+
+package_specific_register () {
+    export PATH=${INSTALL_PATH}/bin:${PATH}
+}
+

--- a/deal.II/packages/trilinos.package
+++ b/deal.II/packages/trilinos.package
@@ -1,3 +1,7 @@
+if [ ${TRILINOS_MAJOR_VERSION} = "AUTO" ]; then
+  TRILINOS_MAJOR_VERSION=12
+fi
+
 if [ ${TRILINOS_MAJOR_VERSION} = "11" ]; then
   SOURCE=https://trilinos.org/oldsite/download/files/
   VERSION=11.6.2

--- a/deal.II/packages/trilinos.package
+++ b/deal.II/packages/trilinos.package
@@ -1,9 +1,18 @@
-VERSION=12.2.1
+if [ ${TRILINOS_MAJOR_VERSION} = "11" ]; then
+  SOURCE=https://trilinos.org/oldsite/download/files/
+  VERSION=11.6.2
+  CHECKSUM=15ea6af5559f872919ff19fe5a322eb6
+fi
+
+if [ ${TRILINOS_MAJOR_VERSION} = "12" ]; then
+  SOURCE=http://trilinos.csbsju.edu/download/files/
+  VERSION=12.2.1
+  CHECKSUM=760f14cbce482b4b9a41d1c18297b531
+fi
+
 NAME=trilinos-${VERSION}-Source
-SOURCE=http://trilinos.csbsju.edu/download/files/
 PACKING=.tar.bz2
 DOWNLOADER=curl
-CHECKSUM=760f14cbce482b4b9a41d1c18297b531
 BUILDCHAIN=cmake
 
 #########################################################################

--- a/deal.II/packages/trilinos.package
+++ b/deal.II/packages/trilinos.package
@@ -1,17 +1,16 @@
-if [ ${TRILINOS_MAJOR_VERSION} = "AUTO" ]; then
-  TRILINOS_MAJOR_VERSION=12
-fi
-
-if [ ${TRILINOS_MAJOR_VERSION} = "11" ]; then
-  SOURCE=https://trilinos.org/oldsite/download/files/
-  VERSION=11.6.2
-  CHECKSUM=15ea6af5559f872919ff19fe5a322eb6
-fi
-
-if [ ${TRILINOS_MAJOR_VERSION} = "12" ]; then
+if [ ${TRILINOS_MAJOR_VERSION} = "AUTO" ] || [ ${TRILINOS_MAJOR_VERSION} = "12" ]; then
   SOURCE=http://trilinos.csbsju.edu/download/files/
   VERSION=12.2.1
   CHECKSUM=760f14cbce482b4b9a41d1c18297b531
+
+elif [ ${TRILINOS_MAJOR_VERSION} = "11" ]; then
+  SOURCE=https://trilinos.org/oldsite/download/files/
+  VERSION=11.6.2
+  CHECKSUM=15ea6af5559f872919ff19fe5a322eb6
+
+else
+  cecho ${BAD} "Unknown Trilinos version ${TRILINOS_MAJOR_VERSION} forced, please use AUTO|12|11."
+  exit
 fi
 
 NAME=trilinos-${VERSION}-Source

--- a/deal.II/platforms/supported/fedora22.platform
+++ b/deal.II/platforms/supported/fedora22.platform
@@ -35,4 +35,3 @@ once:petsc
 once:slepc
 dealii
 )
-

--- a/deal.II/platforms/supported/ubuntu12.platform
+++ b/deal.II/platforms/supported/ubuntu12.platform
@@ -19,6 +19,7 @@
 #
 # Define the packages this platform needs
 PACKAGES=(
+once:cmake
 load:dealii-prepare
 once:opencascade
 once:parmetis

--- a/deal.II/platforms/supported/ubuntu12.platform
+++ b/deal.II/platforms/supported/ubuntu12.platform
@@ -24,5 +24,12 @@ once:slepc
 dealii
 )
 
+# The default compiler on ubuntu12 does not support Trilinos 12.
+# Anyhow, the user can decide to use Trilinos 11 or 12, if the
+# version number is not set to AUTO.
+# The last point is due to own compilers (e.g. intel) which support
+# Trilinos 12.
+if [ ${TRILINOS_MAJOR_VERSION} == "AUTO" ]; then
+  TRILINOS_MAJOR_VERSION=11
+fi
 
-TRILINOS_MAJOR_VERSION_AUTO=11

--- a/deal.II/platforms/supported/ubuntu12.platform
+++ b/deal.II/platforms/supported/ubuntu12.platform
@@ -14,6 +14,10 @@
 # Afterwards, you should set your compilers safely:
 # > export CC=mpicc; export CXX=mpicxx; export FC=mpif90; export FF=mpif77
 # and rerun candi again.
+# 
+# To compile deal.II applications, you need to set the following variables
+# > export DEAL_II_DIR=${INSTALL_PATH} (see below for your settings)
+# > export PATH=$DEAL_II_DIR/bin:$PATH
 ##
 
 #

--- a/deal.II/platforms/supported/ubuntu12.platform
+++ b/deal.II/platforms/supported/ubuntu12.platform
@@ -9,7 +9,11 @@
 #        git libblas-dev liblapack-dev libblas3gf liblapack3gf splint \
 #        tcl tcl-dev libsuitesparse-dev libtool libboost-all-dev qt4-dev-tools
 # 
-# Then reboot and run candi again.
+# Then reboot.
+# 
+# Afterwards, you should set your compilers safely:
+# > export CC=mpicc; export CXX=mpicxx; export FC=mpif90; export FF=mpif77
+# and rerun candi again.
 ##
 
 #

--- a/deal.II/platforms/supported/ubuntu12.platform
+++ b/deal.II/platforms/supported/ubuntu12.platform
@@ -4,7 +4,10 @@
 # This build script assumes that you have several packages already
 # installed via ubuntu's apt-get using the following commands:
 #
-# > sudo apt-get install build-essential automake autoconf gfortran openmpi-bin openmpi-common libopenmpi-dev cmake subversion git libblas-dev liblapack-dev libblas3gf liblapack3gf splint tcl tcl-dev environment-modules libsuitesparse-dev libtool libboost-all-dev qt4-dev-tools
+# > sudo apt-get install build-essential automake autoconf gfortran \
+#        openmpi-bin openmpi-common libopenmpi-dev cmake subversion \
+#        git libblas-dev liblapack-dev libblas3gf liblapack3gf splint \
+#        tcl tcl-dev libsuitesparse-dev libtool libboost-all-dev qt4-dev-tools
 # 
 # Then reboot and run candi again.
 ##

--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -72,6 +72,11 @@ fi
 
 #########################################################################
 
+# If you want to use Trilions, decide if you want v11.x.x or v12.x.x
+TRILINOS_MAJOR_VERSION=12
+
+#########################################################################
+
 # Do you want to use MKL?
 MKL=OFF
 # MKL_DIR=

--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -72,7 +72,7 @@ fi
 
 #########################################################################
 
-# If you want to use Trilions, decide if you want v11.x.x or v12.x.x
+# If you want to use Trilions, decide if you want v12.x.x (AUTO) or v11.x.x
 TRILINOS_MAJOR_VERSION=AUTO
 #TRILINOS_MAJOR_VERSION=11
 #TRILINOS_MAJOR_VERSION=12


### PR DESCRIPTION
This PR gives the opportunity to use either an automatically derived or a forced major version of Trilinos for the deal.II package.
It includes the PR #37 with contributions of @tjhei  and @Rombur , furthermore the last approach of the PR #37 has been extended, such that the file candi.sh does not introduce special variables for Trilinos compiled within the deal.II platform. This was done by the commit e307fb9 .
Furthermore, for the ubuntu 12.04 platform, some minor changes were done with the commits c1b57bb and cece3f4 .
Unfortunately, the currently shipped version 2.8.7 of cmake from ubuntu 12 is not recent enough (at least 2.8.8) to compile deal.II v8.3.0, such that I added a cmake.package file and included it into the build of ubuntu12.platform with the commit fb577db . Cmake is installed within the deal.II installation folder and the user (!) must set the PATH environment variable correctly to use cmake for deal.II applications.
Before the PR can be merged, an additional help message text (how to set up the PATH correctly after the build) must be included for the ubuntu12.platform.

The current changes has been successfully testet on
* vagrant clean virtual machine having ubuntu 12.04 (automatically chooses Trilinos 11)
* CentOS 7.1, using AUTO and forced 11 and forced 12 version request for Trilinos

@Rombur and @tjhei do you have further issues?