### PR TITLE
allow mirror URLs and improve tarball hashing

### DIFF
--- a/deal.II/packages/trilinos.package
+++ b/deal.II/packages/trilinos.package
@@ -17,6 +17,7 @@ NAME=trilinos-${VERSION}-Source
 PACKING=.tar.bz2
 DOWNLOADER=curl
 BUILDCHAIN=cmake
+URLS="https://www.ces.clemson.edu/dealii/mirror/${NAME}${PACKING} ${SOURCE}${NAME}${PACKING}"
 
 #########################################################################
 


### PR DESCRIPTION
- packages can overwrite download urls by using the format URLS="url1
url2 url3"
- this allows us to specify alternate download locations and filenames
- the download_file() function now robustly checks downloads
before/after downloading