### PR TITLE
candi: package_fetch restructuring

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -216,7 +216,7 @@ download_archive () {
         # Download.
         # If curl or wget is failing, continue this loop for trying an other mirror.
         if [ ${DOWNLOADER} = "curl" ] && [ ${CURL_DOWNLOADER_AVAILABLE} = "true" ] ; then
-            curl -O ${url} || continue
+            curl -k -O ${url} || continue
         else
             wget --no-check-certificate ${url} -O ${ARCHIVE_FILE} || continue
         fi

--- a/candi.sh
+++ b/candi.sh
@@ -116,6 +116,99 @@ quit_if_fail() {
     fi
 }
 
+#verify_archive():
+#  return -1: internal error
+#  return 0: CHECKSUM is matching
+#  return 1: No checksum provided
+#  return 2: Package not found
+#  return 3: CHECKSUM mismatch
+#  return 4: Neither md5 nor md5sum found
+verify_archive() {
+    ARCHIVE_FILE=$1
+    
+    # Check checksum has been specified for the package
+    if [ -z "${CHECKSUM}" ]; then
+        cecho ${WARN} "No checksum for ${ARCHIVE_FILE}"
+        return 1
+    fi
+    
+    # Skip checksum if asked to ignore
+    if [ "${CHECKSUM}" = "ignore" ]; then
+        cecho ${WARN} "Skipped checksum check for ${ARCHIVE_FILE}"
+        return 1
+    fi
+    
+    # Make sure the archive was downloaded
+    if [ ! -e ${ARCHIVE_FILE} ]; then
+        return 2
+    fi
+    
+    cecho ${GOOD} "Verifying ${ARCHIVE_FILE}"
+    
+    # Verify checksum using md5/md5sum
+    if builtin command -v md5 > /dev/null; then
+        test "${CHECKSUM}" = "$(md5 -q ${ARCHIVE_FILE})"
+        if [ $? = 0 ]; then
+            echo "${ARCHIVE_FILE}: OK"
+            return 0
+        else
+            echo "${ARCHIVE_FILE}: FAILED"
+            return 3
+        fi
+    
+    elif builtin command -v md5sum > /dev/null; then
+        echo "${CHECKSUM}  ${ARCHIVE_FILE}" | md5sum --check -
+        if [ $? = 0 ]; then
+            return 0
+        else
+            return 3
+        fi
+    
+    else
+        cecho ${BAD} "Neither md5 nor md5sum were found in the PATH"
+        return 4
+    fi
+    
+    # Internal error: we should never reach this point, but to be sure we
+    return -1
+}
+
+download_archive () {
+    ARCHIVE_FILE=$1
+    
+    # Only download archives that do not exist
+    if [ ! -e ${ARCHIVE_FILE} ]; then
+        if [ ${DOWNLOADER} = "curl" ] && [ ${CURL_DOWNLOADER_AVAILABLE} = "true" ] ; then
+            curl -O ${SOURCE}${ARCHIVE_FILE} || { rm ${SOURCE}${ARCHIVE_FILE}; exit 1; }
+        else
+            if [ ${STABLE_BUILD} = false ] && [ ${USE_SNAPSHOTS} = true ]; then
+                wget --retry-connrefused --no-check-certificate --server-response -c ${SOURCE}${ARCHIVE_FILE} -O ${ARCHIVE_FILE} || { rm ${ARCHIVE_FILE}; exit 1; }
+            else
+                wget --retry-connrefused --no-check-certificate -c ${SOURCE}${ARCHIVE_FILE} -O ${ARCHIVE_FILE} || { rm ${ARCHIVE_FILE}; exit 1; }
+            fi
+        fi
+    else
+        cecho ${GOOD} "Skipping download (archive file exists)"
+    fi
+    
+    # Download again when using snapshots and unstable packages, but
+    # only when the timestamp has changed
+    if [ ${STABLE_BUILD} = false ] && [ ${USE_SNAPSHOTS} = true ]; then
+        wget --timestamping --retry-connrefused --no-check-certificate ${SOURCE}${ARCHIVE_FILE} || { rm ${SOURCE}${ARCHIVE_FILE}; exit 1; }
+        cecho ${GOOD} "Downloading new snap shot archive file..."
+    fi
+
+    # Make sure the archive was downloaded
+    if [ ! -e ${ARCHIVE_FILE} ]; then
+        cecho ${BAD} "${ARCHIVE_FILE} does not exist. Please download first."
+        exit 1
+    fi
+    
+    # Verify the download
+    verify_archive ${ARCHIVE_FILE}
+    quit_if_fail "Error verifying checksum for ${ARCHIVE_FILE}\nMake sure that you are connected to the internet.\nIf a corrupted file has been downloaded, please remove\n   ${DOWNLOAD_PATH}/${NAME}${PACKING}\nbefore you restart candi!"
+}
+
 package_fetch () {
     # First, make sure we're in the right directory before downloading
     cd ${DOWNLOAD_PATH}
@@ -124,24 +217,8 @@ package_fetch () {
 
     # Fetch the package appropriately from its source
     if [ ${PACKING} = ".tar.bz2" ] || [ ${PACKING} = ".tar.gz" ] || [ ${PACKING} = ".tbz2" ] || [ ${PACKING} = ".tgz" ] || [ ${PACKING} = ".tar.xz" ] || [ ${PACKING} = ".zip" ]; then
-        # Only download archives that do not exist
-        if [ ! -e ${NAME}${PACKING} ]; then
-            if [ ${DOWNLOADER} = "curl" ] && [ ${CURL_DOWNLOADER_AVAILABLE} = "true" ] ; then
-                curl -O ${SOURCE}${NAME}${PACKING} || { rm ${SOURCE}${NAME}${PACKING}; exit 1; }
-            else
-                if [ ${STABLE_BUILD} = false ] && [ ${USE_SNAPSHOTS} = true ]; then
-                    wget --retry-connrefused --no-check-certificate --server-response -c ${SOURCE}${NAME}${PACKING} -O ${NAME}${PACKING} || { rm ${NAME}${PACKING}; exit 1; }
-                else
-                    wget --retry-connrefused --no-check-certificate -c ${SOURCE}${NAME}${PACKING} -O ${NAME}${PACKING} || { rm ${NAME}${PACKING}; exit 1; }
-                fi
-            fi
-        fi
-        
-        # Download again when using snapshots and unstable packages, but
-        # only when the timestamp has changed
-        if [ ${STABLE_BUILD} = false ] && [ ${USE_SNAPSHOTS} = true ]; then
-            wget --timestamping --retry-connrefused --no-check-certificate ${SOURCE}${NAME}${PACKING} || { rm ${SOURCE}${NAME}${PACKING}; exit 1; }
-        fi
+        download_archive ${NAME}${PACKING}
+    
     elif [ ${PACKING} = "hg" ]; then
         cd ${UNPACK_PATH}
         # Suitably clone or update hg repositories
@@ -191,48 +268,6 @@ package_fetch () {
     # Quit with a useful message if something goes wrong
     quit_if_fail "Error fetching ${NAME}."
 }
-
-package_verify() {
-    # First make sure we're in the right directory before verifying checksum
-    cd ${DOWNLOAD_PATH}
-
-    # Only need to verify archives
-    if [ ${PACKING} = ".tar.bz2" ] || [ ${PACKING} = ".tar.gz" ] ||  [ ${PACKING} = ".tbz2" ] || [ ${PACKING} = ".tgz" ] || [ ${PACKING} = ".tar.xz" ] || [ ${PACKING} = ".zip" ]; then
-        cecho ${GOOD} "Verifying ${NAME}${PACKING}"
-      
-        # Check checksum has been specified for the package
-        if [ -z "${CHECKSUM}" ]; then
-            cecho ${WARN} "No checksum for ${NAME}${PACKING}"
-            return 1
-        fi
-        
-        # Skip checksum if asked to ignore
-        if [ "${CHECKSUM}" = "ignore" ]; then
-            cecho ${WARN} "Skipped checksum check for ${NAME}${PACKING}"
-            return 1
-        fi
-        
-        # Make sure the archive was downloaded
-        if [ ! -e ${NAME}${PACKING} ]; then
-            cecho ${BAD} "${NAME}${PACKING} does not exist. Please download first."
-            exit 1
-        fi
-        
-        # Verify checksum using md5/md5sum
-        if builtin command -v md5 > /dev/null; then
-            test "${CHECKSUM}" = "$(md5 -q ${NAME}${PACKING})" && echo "${NAME}${PACKING}: OK"
-        elif builtin command -v md5sum > /dev/null; then
-            echo "${CHECKSUM}  ${NAME}${PACKING}" | md5sum --check -
-        else
-            cecho ${BAD} "Neither md5 nor md5sum were found in the PATH"
-            return 1
-        fi
-    fi
-    
-    # Quit with a useful message if something goes wrong
-    quit_if_fail "Error verifying checksum for ${NAME}${PACKING}\nMake sure that you are connected to the internet.\nIf a corrupted file has been downloaded, please remove\n   ${DOWNLOAD_PATH}/${NAME}${PACKING}\nbefore you restart candi!"
-}
-
 
 package_unpack() {
     # First make sure we're in the right directory before unpacking
@@ -795,7 +830,6 @@ for PACKAGE in ${PACKAGES[@]}; do
     if [ ${SKIP} = false ]; then
         # Fetch, unpack and build the current package
         package_fetch
-        package_verify
         package_unpack
         package_build
     else

--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -8,6 +8,10 @@ PROJECT=deal.II
 CLEAN_BUILD=false
 
 #########################################################################
+# Set up a (local) mirror server url
+MIRROR="https://www.ces.clemson.edu/dealii/mirror/"
+
+#########################################################################
 #Choose components of deal.II
 DEAL_CONFOPTS=" \
 -D CMAKE_BUILD_TYPE=DebugRelease \

--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -8,8 +8,8 @@ PROJECT=deal.II
 CLEAN_BUILD=false
 
 #########################################################################
-# Set up a (local) mirror server url
-MIRROR="https://www.ces.clemson.edu/dealii/mirror/"
+# Set up a (local) mirror server url, to speed up your package downloads:
+#MIRROR=
 
 #########################################################################
 #Choose components of deal.II

--- a/project-deal.II.cfg
+++ b/project-deal.II.cfg
@@ -9,7 +9,7 @@ CLEAN_BUILD=false
 
 #########################################################################
 # Set up a (local) mirror server url, to speed up your package downloads:
-#MIRROR=
+MIRROR="https://www.ces.clemson.edu/dealii/mirror/"
 
 #########################################################################
 #Choose components of deal.II


### PR DESCRIPTION
* package_fetch redesign: for archives (.tar.bz2, .tar.gz, ...) a new download_archive function is called.
* package_verify: this is only needed for archives, and thus it is moved little above under the name verify_archive
* verify_archive is called by download_archive
* Further devolopment: make the download + checksumming process more dynamic (auto rm corrupted file, mirrors)

This patch solves the first part of PR #41. The second part (mirror list) is coming soon.