### PR TITLE
changes to CONFIGURATION_PATH

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -630,7 +630,7 @@ default DOWNLOAD_PATH=${PREFIX_PATH}/src
 default UNPACK_PATH=${PREFIX_PATH}/${PROJECT}-unpack
 default BUILD_PATH=${PREFIX_PATH}/${PROJECT}-build
 default INSTALL_PATH=${PREFIX_PATH}/${PROJECT}
-default CONFIGURATION_PATH=${PREFIX_PATH}/${PROJECT}/share/configuration
+default CONFIGURATION_PATH=${INSTALL_PATH}/configuration
 
 default CLEAN_BUILD=false
 default STABLE_BUILD=true

--- a/project-deal.II-toolchain.cfg
+++ b/project-deal.II-toolchain.cfg
@@ -19,7 +19,7 @@ CLEAN_BUILD=false
 INSTALL_PATH=${PREFIX_PATH}/${PROJECT}
 
 # Where do you want the configuration files placed?
-CONFIGURATION_PATH=${PREFIX_PATH}/${PROJECT}/share/configuration
+#CONFIGURATION_PATH=${INSTALL_PATH}/configuration
 
 #########################################################################
 # Set up mirror server url(s), to speed up downloads, e.g.


### PR DESCRIPTION
- do not manually set the configuration path
- change the default to be under the installation path (only important
if you change the installation path)
- do not include ``share/`` in the path (this is an otherwise empty directory)