### PR TITLE
Add debian9.platform

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -587,6 +587,7 @@ guess_platform() {
         local CODENAME=$(lsb_release -c -s)
         local DESCRIPTION=$(lsb_release -d -s)
         case ${DISTRO}:${CODENAME}:${DESCRIPTION} in
+	    *:*:*Debian*\ 9*)      echo debian9;;
             *:*:*Ubuntu*\ 12*)     echo ubuntu12;;
             *:*:*Ubuntu*\ 14*)     echo ubuntu14;;
             *:*:*Ubuntu*\ 15*)     echo ubuntu15;;

--- a/candi.sh
+++ b/candi.sh
@@ -587,7 +587,7 @@ guess_platform() {
         local CODENAME=$(lsb_release -c -s)
         local DESCRIPTION=$(lsb_release -d -s)
         case ${DISTRO}:${CODENAME}:${DESCRIPTION} in
-	    *:*:*Debian*\ 9*)      echo debian9;;
+            *:*:*Debian*\ 9*)      echo debian9;;
             *:*:*Ubuntu*\ 12*)     echo ubuntu12;;
             *:*:*Ubuntu*\ 14*)     echo ubuntu14;;
             *:*:*Ubuntu*\ 15*)     echo ubuntu15;;

--- a/deal.II-toolchain/platforms/supported/debian9.platform
+++ b/deal.II-toolchain/platforms/supported/debian9.platform
@@ -1,9 +1,9 @@
 
 # debian 9
 # This build script assumes that you have several packages already
-# installed via ubuntu's apt-get using the following commands:
+# installed via Debian's apt using the following commands:
 #
-# > sudo apt-get install build-essential lsb-release wget \
+# > sudo apt install build-essential lsb-release wget \
 #   automake autoconf gfortran \
 #   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
 #   libblas-dev liblapack-dev libblas3 liblapack3 \

--- a/deal.II-toolchain/platforms/supported/debian9.platform
+++ b/deal.II-toolchain/platforms/supported/debian9.platform
@@ -1,0 +1,14 @@
+
+# debian 9
+# This build script assumes that you have several packages already
+# installed via ubuntu's apt-get using the following commands:
+#
+# > sudo apt-get install build-essential lsb-release wget \
+#   automake autoconf gfortran \
+#   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
+#   libblas-dev liblapack-dev libblas3 liblapack3 \
+#   libsuitesparse-dev libtool libboost-all-dev \
+#   splint tcl tcl-dev environment-modules qt4-dev-tools
+#
+# Then run candi again.
+##


### PR DESCRIPTION
Related Notes; this pull  request will get rid of needing --platform=ubuntu16 to build on Debian 9, but there are additional issues with actually using deal.ii on Debian 9 when installed via candi.

libdeal.ii-8.4.2 is packaged in Debian 9. 
Then the examples are in libdeal.ii-doc at /usr/share/doc/libdeal.ii-doc/examples
Building examples with these debian packages (cmake -DDEAL_II_DIR=/usr) do not give me the error below, which I get with the candi-installed libdeal.ii 8.5.0:


candi builds libdeal.ii-8.5.0 OK on Debian 9, but I get error thereafter trying to build examples:

$ cmake -DDEAL_II_DIR=/franckm/deal.ii-candi/deal.II-v8.5.0
...
#  Project  step-1  set up with  deal.II-8.5.0  found at
#      /srv/local/Disk_Space/franckm/deal.ii-candi/deal.II-v8.5.0
...
$ -- Build files have been written to: /srv/local/Disk_Space/franckm/deal.ii-candi/deal.II-v8.5.0/examples/step-1
franckm@orange:/srv/local/Disk_Space/franckm/deal.ii-candi/deal.II-v8.5.0/examples/step-1$ 
franckm@orange:/srv/local/Disk_Space/franckm/deal.ii-candi/deal.II-v8.5.0/examples/step-1$ make run
Scanning dependencies of target step-1
[ 33%] Building CXX object CMakeFiles/step-1.dir/step-1.cc.o
[ 66%] Linking CXX executable step-1
[ 66%] Built target step-1
Scanning dependencies of target run
[100%] Run step-1 with Debug configuration
./step-1: error while loading shared libraries: libmpi.so.1: cannot open shared object file: No such file or directory
CMakeFiles/run.dir/build.make:57: recipe for target 'CMakeFiles/run' failed
make[3]: *** [CMakeFiles/run] Error 127
CMakeFiles/Makefile2:264: recipe for target 'CMakeFiles/run.dir/all' failed
make[2]: *** [CMakeFiles/run.dir/all] Error 2
CMakeFiles/Makefile2:271: recipe for target 'CMakeFiles/run.dir/rule' failed
make[1]: *** [CMakeFiles/run.dir/rule] Error 2
Makefile:196: recipe for target 'run' failed
make: *** [run] Error 2
franckm@orange:/srv/local/Disk_Space/franckm/deal.ii-candi/deal.II-v8.5.0/examples/step-1$ 

This can be overcome by 

cd /usr/lib/x86_64-inux-gnu
sudo ln -s libmpi.so.20 libmpi.so.1

then step-1 compiles and runs. This is weird because cmake seemed to have the correct libmpi.so (not libmpi.so.1 which is present on Debian8, not Debian9):

franckm@orange:/srv/local/Disk_Space/franckm/deal.ii-candi/deal.II-v8.5.0/examples/step-1/CMakeFiles/step-1.dir$ grep libmpi.so *
build.make:step-1: /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so

franckm@orange:/srv/local/Disk_Space/franckm/deal.ii-candi/deal.II-v8.5.0/examples/step-1/CMakeFiles/step-1.dir$ ls -l /usr/lib/x86_64-linux-gnu/libmpi.so* 
lrwxrwxrwx 1 root root 27 Jun 30 21:57 /usr/lib/x86_64-linux-gnu/libmpi.so -> /etc/alternatives/libmpi.so
lrwxrwxrwx 1 root root 12 Aug  1 12:46 /usr/lib/x86_64-linux-gnu/libmpi.so.1 -> libmpi.so.20
lrwxrwxrwx 1 root root 16 Feb 10 07:43 /usr/lib/x86_64-linux-gnu/libmpi.so.20 -> libmpi.so.20.0.2
lrwxrwxrwx 1 root root 28 Feb 10 07:43 /usr/lib/x86_64-linux-gnu/libmpi.so.20.0.2 -> openmpi/lib/libmpi.so.20.0.2
franckm@orange:/srv/local/Disk_Space/franckm/deal.ii-candi/deal.II-v8.5.0/examples/step-1/CMakeFiles/step-1.dir$ 

(Note the libmpi.so.1 I created manually)



